### PR TITLE
Fix duplicate event creation and ticket counter sync for organizer flow

### DIFF
--- a/src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx
+++ b/src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx
@@ -15,6 +15,7 @@ import {
   createOrganizerEvent,
   getOrganizerEventById,
   saveOrganizerEventDraft,
+  updateOrganizerEvent,
 } from "@/features/organizer/events/services/create-event.service";
 import { getOrganizerTicketTypes } from "@/features/organizer/events/services/ticket-types.service";
 import type {
@@ -213,12 +214,6 @@ export function OrganizerCreateEventStepFiveContent() {
       }
     }
 
-    const totalTickets = Number(
-      ticketTypes.reduce(
-        (sum, ticket) => sum + toNumberOrZero(ticket.quantity),
-        0,
-      ),
-    );
     const minPriceFromTickets =
       ticketTypes.length > 0
         ? Math.min(...ticketTypes.map((ticket) => toNumberOrZero(ticket.price)))
@@ -307,19 +302,36 @@ export function OrganizerCreateEventStepFiveContent() {
     setIsSubmittingWorkflow(true);
     try {
       const createPayload = await buildCreatePayload();
-      const createResult = await createOrganizerEvent(createPayload);
-      const createdEvent = getApiResultData(
-        createResult as ApiResult<OrganizerEvent>,
+      const payloadToSubmit = {
+        ...createPayload,
+        status: "PENDING" as const,
+      };
+      const resolvedEventId = await resolveEventId();
+
+      const submitResult = await updateOrganizerEvent(
+        resolvedEventId,
+        payloadToSubmit,
       );
-      if (createdEvent?.id) {
-        setEventId(createdEvent.id);
-        setOrganizerDraftEventId(createdEvent.id);
+      let submittedEvent = getApiResultData(
+        submitResult as ApiResult<OrganizerEvent>,
+      );
+
+      if (!submittedEvent?.id) {
+        const fallbackCreateResult = await createOrganizerEvent(payloadToSubmit);
+        submittedEvent = getApiResultData(
+          fallbackCreateResult as ApiResult<OrganizerEvent>,
+        );
       }
 
-      setStatus(String(createdEvent?.status ?? "PENDING"));
+      if (submittedEvent?.id) {
+        setEventId(submittedEvent.id);
+        setOrganizerDraftEventId(submittedEvent.id);
+      }
+
+      setStatus(String(submittedEvent?.status ?? "PENDING"));
       showToast({
         tone: "success",
-        message: "Sự kiện đã được tạo thành công.",
+        message: "Sự kiện đã được gửi duyệt thành công.",
       });
       await router.push("/organizer/events");
     } catch (error) {

--- a/src/features/organizer/events/services/ticket-types.service.ts
+++ b/src/features/organizer/events/services/ticket-types.service.ts
@@ -58,7 +58,7 @@ function mapTicketTypeItem(item: unknown, index: number): OrganizerTicketType {
       "Unnamed Ticket",
     price: toNumberOrZero(value.price),
     quantity: toNumberOrZero(value.quantity),
-    soldQuantity: toNumberOrZero(value.soldQuantity),
+    soldQuantity: toNumberOrZero(value.soldQuantity ?? value.sold_quantity),
     saleStart:
       (typeof value.saleStart === "string" && value.saleStart) ||
       (typeof value.sale_start === "string" && value.sale_start) ||
@@ -122,14 +122,8 @@ export async function getOrganizerTicketTypes(
     >(`${ORGANIZER_API_BASE}/events/${eventId}/ticket-types`, { params });
 
     ensureApiResultSuccess(response.data, "Cannot load ticket types.");
-    const pagedData = getApiResultData(
-      response.data as ApiResult<unknown>,
-    ) as Record<string, unknown>;
-
-    // Backend returns PagedResponse with "items" field
-    const items: unknown[] = Array.isArray(pagedData?.items)
-      ? pagedData.items
-      : [];
+    const payload = getApiResultData(response.data as ApiResult<unknown>);
+    const items = getTicketItemsFromPayload(payload);
 
     return items.map((item, index) => mapTicketTypeItem(item, index));
   } catch (error) {

--- a/src/features/organizer/events/types.ts
+++ b/src/features/organizer/events/types.ts
@@ -27,6 +27,7 @@ export type OrganizerEventTicketCountersPayload = {
   availableTickets?: number;
   total_tickets?: number;
   availability_tickets?: number;
+  availibility_tickets?: number;
 };
 
 export type OrganizerUpdateEventPayload = Partial<
@@ -74,6 +75,7 @@ export type OrganizerEvent = OrganizerCreateEventPayload & {
   availableTickets?: number;
   total_tickets?: number;
   availability_tickets?: number;
+  availibility_tickets?: number;
 };
 
 export type OrganizerEventsPageData = {

--- a/src/features/organizer/shared/OrganizerTicketTypesEditor.tsx
+++ b/src/features/organizer/shared/OrganizerTicketTypesEditor.tsx
@@ -179,6 +179,7 @@ export function OrganizerTicketTypesEditor({
       availableTickets,
       total_tickets: totalTickets,
       availability_tickets: availableTickets,
+      availibility_tickets: availableTickets,
     });
   }, [eventId]);
 


### PR DESCRIPTION
### Motivation
- Submitting in Step 5 always created a new event instead of updating the existing draft, causing duplicate events when organizer submits for approval. 
- Ticket counter fields on the event (`total_tickets` / `availability_tickets`) were not always updated because ticket-type list parsing missed some backend payload shapes. 
- Backend variability (snake_case `sold_quantity` and a possible `availibility_tickets` variant) caused incorrect available ticket calculations and incompatibility when syncing counters.

### Description
- Change Step 5 submit flow to call `updateOrganizerEvent(eventId, ...)` with `status: "PENDING"` and only fall back to `createOrganizerEvent(...)` if the update result does not include an `id`, so existing drafts are updated instead of creating duplicates (`src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx`).
- Use `getTicketItemsFromPayload` to extract ticket-type arrays from multiple payload shapes (`items`, `content`, `ticketTypes`, or direct array) and map items consistently, so ticket lists are loaded reliably (`src/features/organizer/events/services/ticket-types.service.ts`).
- Normalize `sold_quantity` (snake_case) when mapping ticket items to ensure `soldQuantity` is accurate for availability calculations (`src/features/organizer/events/services/ticket-types.service.ts`).
- Add `availibility_tickets` (compatibility with backend variants) to event ticket counters types and include it when syncing counters from ticket-type changes (`src/features/organizer/events/types.ts`, `src/features/organizer/shared/OrganizerTicketTypesEditor.tsx`).
- Ensure counter sync (`syncEventTicketCounters`) calls `updateOrganizerEvent` with both camelCase and snake_case/variant fields so backends expecting different keys receive updated values (`src/features/organizer/shared/OrganizerTicketTypesEditor.tsx`).

### Testing
- Ran `npm run lint` which completed successfully with the repository’s existing warnings and no new errors. 
- Ran targeted ESLint on modified files with `npx eslint src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx src/features/organizer/events/services/ticket-types.service.ts src/features/organizer/events/types.ts src/features/organizer/shared/OrganizerTicketTypesEditor.tsx` which passed (only pre-existing warnings remained).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec37de23e48325a088a30fcacdf54c)