### PR TITLE
Preserve draft datetimes and add validation for Step 2 event save

### DIFF
--- a/src/features/organizer/createEvent/OrganizerCreateEventStepTwoContent.tsx
+++ b/src/features/organizer/createEvent/OrganizerCreateEventStepTwoContent.tsx
@@ -96,11 +96,17 @@ export function OrganizerCreateEventStepTwoContent() {
   };
 
   const mergeCurrentStepPayload = () => {
+    const currentDraftPayload = getOrganizerDraftPayload() ?? {};
+    const nextStartTime =
+      toIsoString(startDateTime) ?? currentDraftPayload.startTime;
+    const nextEndTime = toIsoString(endDateTime) ?? currentDraftPayload.endTime;
+
     const payload = {
       venueName: venueName.trim() || "TBD Venue",
       address: address.trim() || "TBD Address",
-      startTime: toIsoString(startDateTime),
-      endTime: toIsoString(endDateTime),
+      city: currentDraftPayload.city || "Ho Chi Minh",
+      startTime: nextStartTime,
+      endTime: nextEndTime,
     };
 
     mergeOrganizerDraftPayload(payload);
@@ -115,6 +121,28 @@ export function OrganizerCreateEventStepTwoContent() {
     try {
       const payload = mergeCurrentStepPayload();
       const draftPayload = getOrganizerDraftPayload();
+      const startTimestamp = payload.startTime
+        ? new Date(payload.startTime).getTime()
+        : Number.NaN;
+      const endTimestamp = payload.endTime
+        ? new Date(payload.endTime).getTime()
+        : Number.NaN;
+
+      if (Number.isNaN(startTimestamp) || Number.isNaN(endTimestamp)) {
+        showToast({
+          tone: "error",
+          message: "Vui lòng nhập đầy đủ thời gian bắt đầu và kết thúc.",
+        });
+        return;
+      }
+
+      if (endTimestamp <= startTimestamp) {
+        showToast({
+          tone: "error",
+          message: "Thời gian kết thúc phải sau thời gian bắt đầu.",
+        });
+        return;
+      }
 
       if (eventId) {
         await updateOrganizerEvent(eventId, {


### PR DESCRIPTION
### Motivation
- Users could fail to save at Step 2 because `startTime`/`endTime` in the payload became empty or unparsable, causing the backend to reject the update.

### Description
- `mergeCurrentStepPayload` now reads the existing draft via `getOrganizerDraftPayload()` and falls back to saved `startTime`/`endTime` when the datetime inputs are empty or invalid in `src/features/organizer/createEvent/OrganizerCreateEventStepTwoContent.tsx`.
- Added a `city` fallback (from draft or default `"Ho Chi Minh"`) to avoid sending incomplete update payloads.
- Added client-side validation that both start and end timestamps must parse and that `endTime` is strictly after `startTime`, with Vietnamese toast error messages when validation fails.
- Payload is merged with `mergeOrganizerDraftPayload` and the update call still only runs when an `eventId` is present.

### Testing
- Ran `npx eslint src/features/organizer/createEvent/OrganizerCreateEventStepTwoContent.tsx` which completed successfully and reported a single unrelated warning (`Unused eslint-disable directive`).
- No other automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3f72fae883258e1eca4b272c6eb4)