### PR TITLE
Persist and submit organizer event drafts; add payload merging and submit endpoint

### DIFF
--- a/src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx
+++ b/src/features/organizer/createEvent/OrganizerCreateEventStepFiveContent.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import { AlertCircle, CheckCircle2, Save } from "lucide-react";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { getApiErrorMessage, getApiResultData } from "@/features/auth/utils";
 import type { ApiResult } from "@/features/auth/types";
@@ -10,11 +9,12 @@ import {
   getOrganizerDraftPayload,
   mergeOrganizerDraftPayload,
   setOrganizerDraftEventId,
+  setOrganizerDraftPayload,
 } from "@/features/organizer/events/services/draft-storage";
 import {
-  createOrganizerEvent,
   getOrganizerEventById,
   saveOrganizerEventDraft,
+  submitOrganizerEvent,
   updateOrganizerEvent,
 } from "@/features/organizer/events/services/create-event.service";
 import { getOrganizerTicketTypes } from "@/features/organizer/events/services/ticket-types.service";
@@ -114,6 +114,31 @@ function buildFallbackDraftPayload(): OrganizerCreateEventPayload {
   };
 }
 
+function mergePayloadWithFallback(
+  payload?: Partial<OrganizerCreateEventPayload>,
+): OrganizerCreateEventPayload {
+  const fallback = buildFallbackDraftPayload();
+
+  return {
+    ...fallback,
+    ...payload,
+    title: payload?.title?.trim() || fallback.title,
+    shortDescription:
+      payload?.shortDescription?.trim() || fallback.shortDescription,
+    description: payload?.description?.trim() || fallback.description,
+    category: payload?.category?.trim() || fallback.category,
+    venueName: payload?.venueName?.trim() || fallback.venueName,
+    address: payload?.address?.trim() || fallback.address,
+    city: payload?.city?.trim() || fallback.city,
+    bannerUrl: payload?.bannerUrl?.trim() || fallback.bannerUrl,
+    startTime: payload?.startTime?.trim() || fallback.startTime,
+    endTime: payload?.endTime?.trim() || fallback.endTime,
+    visibility: "PUBLIC",
+    minPrice: Number(payload?.minPrice ?? fallback.minPrice),
+    status: (payload?.status ?? "DRAFT") as OrganizerCreateEventPayload["status"],
+  };
+}
+
 export function OrganizerCreateEventStepFiveContent() {
   const router = useRouter();
   const [eventId, setEventId] = useState<string | null>(null);
@@ -130,15 +155,15 @@ export function OrganizerCreateEventStepFiveContent() {
     const storedEventId = getOrganizerDraftEventId();
     const resolvedEventId = queryEventId || storedEventId;
 
+    const localDraftPayload = mergePayloadWithFallback(
+      mapToCreatePayload(getOrganizerDraftPayload()),
+    );
+    setReviewPayload(localDraftPayload);
+
     if (!resolvedEventId) {
-      const localDraftPayload =
-        (getOrganizerDraftPayload() as OrganizerCreateEventPayload | null) ??
-        buildFallbackDraftPayload();
-      setReviewPayload(localDraftPayload);
       return;
     }
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     setEventId(resolvedEventId);
     setOrganizerDraftEventId(resolvedEventId);
 
@@ -154,21 +179,18 @@ export function OrganizerCreateEventStepFiveContent() {
 
         if (eventData) {
           const normalizedEventPayload = mapToCreatePayload(eventData);
-          setReviewPayload((prev) => ({ ...prev, ...normalizedEventPayload }));
+          const hydratedPayload = mergePayloadWithFallback({
+            ...normalizedEventPayload,
+            ...mapToCreatePayload(getOrganizerDraftPayload()),
+          });
+
+          setReviewPayload(hydratedPayload);
+          setOrganizerDraftPayload(hydratedPayload);
         }
       } catch {
         // Keep default status when detail endpoint is not reachable.
       }
     })();
-
-    const localDraftPayload =
-      (getOrganizerDraftPayload() as OrganizerCreateEventPayload | null) ??
-      buildFallbackDraftPayload();
-    const normalizedLocalPayload = mapToCreatePayload(localDraftPayload);
-    setReviewPayload((prev) => ({
-      ...prev,
-      ...normalizedLocalPayload,
-    }));
   }, [router.query.eventId]);
 
   const showToast = (nextToast: ToastState) => {
@@ -177,14 +199,11 @@ export function OrganizerCreateEventStepFiveContent() {
   };
 
   const resolveDraftPayload = () => {
-    const payload =
-      (getOrganizerDraftPayload() as OrganizerCreateEventPayload | null) ??
-      buildFallbackDraftPayload();
-
-    return {
-      ...payload,
+    return mergePayloadWithFallback({
+      ...mapToCreatePayload(getOrganizerDraftPayload()),
+      ...mapToCreatePayload(reviewPayload),
       status: "DRAFT",
-    };
+    });
   };
 
   const toIsoOrFallback = (value: string | undefined, fallback: string) => {
@@ -318,10 +337,11 @@ export function OrganizerCreateEventStepFiveContent() {
       const id = await resolveEventId();
       const createPayload = await buildCreatePayload(id);
 
-      const result = await updateOrganizerEvent(id, {
+      await updateOrganizerEvent(id, {
         ...createPayload,
-        status: "PENDING",
+        status: "DRAFT",
       });
+      const result = await submitOrganizerEvent(id);
 
       const updatedEvent = getApiResultData(
         result as ApiResult<OrganizerEvent>,

--- a/src/features/organizer/createEvent/OrganizerCreateEventStepFourContent.tsx
+++ b/src/features/organizer/createEvent/OrganizerCreateEventStepFourContent.tsx
@@ -1,15 +1,29 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 
 import { OrganizerTicketTypesEditor } from "@/features/organizer/shared/OrganizerTicketTypesEditor";
+import {
+  getOrganizerDraftEventId,
+  setOrganizerDraftEventId,
+} from "@/features/organizer/events/services/draft-storage";
 
 export function OrganizerCreateEventStepFourContent() {
   const router = useRouter();
 
   const eventId = useMemo(() => {
     const queryEventId = router.query.eventId;
-    return typeof queryEventId === "string" ? queryEventId : null;
+    if (typeof queryEventId === "string" && queryEventId.trim()) {
+      return queryEventId;
+    }
+
+    return getOrganizerDraftEventId();
   }, [router.query.eventId]);
+
+  useEffect(() => {
+    if (eventId) {
+      setOrganizerDraftEventId(eventId);
+    }
+  }, [eventId]);
 
   const previousHref = eventId
     ? {

--- a/src/features/organizer/createEvent/OrganizerCreateEventStepThreeContent.tsx
+++ b/src/features/organizer/createEvent/OrganizerCreateEventStepThreeContent.tsx
@@ -12,7 +12,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { getApiErrorMessage } from "@/features/auth/utils";
 import {
+  getOrganizerDraftEventId,
   getOrganizerDraftPayload,
+  setOrganizerDraftEventId,
   setOrganizerDraftPayload,
 } from "@/features/organizer/events/services/draft-storage";
 import { updateOrganizerEvent } from "@/features/organizer/events/services/create-event.service";
@@ -37,13 +39,22 @@ export function OrganizerCreateEventStepThreeContent() {
 
   const eventId = useMemo(() => {
     const queryEventId = router.query.eventId;
-    return typeof queryEventId === "string" ? queryEventId : null;
+    if (typeof queryEventId === "string" && queryEventId.trim()) {
+      return queryEventId;
+    }
+
+    return getOrganizerDraftEventId();
   }, [router.query.eventId]);
+
+  useEffect(() => {
+    if (eventId) {
+      setOrganizerDraftEventId(eventId);
+    }
+  }, [eventId]);
 
   useEffect(() => {
     const draft = getOrganizerDraftPayload();
     if (draft?.bannerUrl) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setBannerUrl(draft.bannerUrl);
     }
   }, []);

--- a/src/features/organizer/events/services/create-event.service.ts
+++ b/src/features/organizer/events/services/create-event.service.ts
@@ -120,6 +120,19 @@ export async function updateOrganizerEvent(eventId: string, payload: OrganizerUp
   }
 }
 
+export async function submitOrganizerEvent(eventId: string) {
+  try {
+    const response = await axiosClient.put<ApiResult<OrganizerEvent>>(
+      `${ORGANIZER_EVENTS_ENDPOINT}/${eventId}/submit`,
+    );
+
+    ensureApiResultSuccess(response.data, "Gui duyet su kien that bai.");
+    return response.data;
+  } catch (error) {
+    throw new Error(getApiErrorMessage(error, "Gui duyet su kien that bai."));
+  }
+}
+
 export async function saveOrganizerEventDraft(payload: OrganizerCreateEventPayload, eventId?: string) {
   if (eventId) {
     return updateOrganizerEvent(eventId, { ...payload, status: "DRAFT" });


### PR DESCRIPTION
### Motivation
- Ensure organizer create-event flow consistently hydrates the review payload from local draft and fetched event data to avoid missing fields and inconsistent state.
- Persist the merged draft back to storage so subsequent steps use the same normalized payload.
- Separate updating the event and submitting it for review via a dedicated submit API to make submission explicit.

### Description
- Added `mergePayloadWithFallback` to normalize and merge partial draft payloads with fallback defaults and trimmed string fields in `OrganizerCreateEventStepFiveContent.tsx`.
- Hydrated `reviewPayload` earlier from local draft and, when fetching an event by ID, merged event data with the local draft and persisted the hydrated payload via `setOrganizerDraftPayload`.
- Modified `handleSubmitWorkflow` to first `updateOrganizerEvent` with `status: "DRAFT"` and then call new `submitOrganizerEvent` which PUTs to `.../events/{id}/submit` in `create-event.service.ts`.
- Updated step components (`StepThree` and `StepFour`) to fallback to `getOrganizerDraftEventId()` when `router.query.eventId` is absent and to persist the resolved eventId via `setOrganizerDraftEventId` in a `useEffect` hook.
- Removed an unnecessary eslint disable and cleaned up imports accordingly.

### Testing
- Ran TypeScript typecheck and the project build and both completed successfully.
- Ran ESLint and autofix where appropriate and no lint errors remain.
- Executed the existing unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec49bd801883258e0d8ebca95a2fe6)